### PR TITLE
Fixed encoding problem concerning UTF-8

### DIFF
--- a/src/spynner/browser.py
+++ b/src/spynner/browser.py
@@ -475,7 +475,9 @@ class Browser(object):
         return res
 
     def _get_html(self):
-        return six.u(self.webframe.toHtml())
+#        return six.u(self.webframe.toHtml())
+# To fix encoding problem concerning Asian languages (git@github.com:hemichael/spynner.git)
+	return unicode(self.webframe.toHtml().toUtf8(), 'utf-8', 'ignore')
 
     def _get_soup(self):
         if not self._html_parser:


### PR DESCRIPTION
When Spynner transforms QString in Qt into Python string, it doesn't take Unicode into account thus Asian languages would turn out to be messy code. 

In ./src/spynner/browser.py (line 477),
modify:
def _get_html(self):
    return six.u(self.webframe.toHtml())
into:
def _get_html(self):
    return unicode(self.webframe.toHtml().toUtf8(), 'utf-8', 'ignore')

Reference: http://zhidao.baidu.com/link?url=JhVecxNsJHGImbDH8-n4sSy4DvA-OdJOhu0Vcc-k08pLyqoz3OItxR4qunT-Wq5k92kAKpfZW2KXhM-J1SUSsEkY7ceDvcTim90sjAf45Im